### PR TITLE
Use HTTPS rubygems.org source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 %w{cache core gen helpers}.each do |p|
   gem "padrino-#{p}", '0.10.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
       tinder (>= 1.4.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activemodel (3.2.12)
       activesupport (= 3.2.12)


### PR DESCRIPTION
This is really just practice for me. :)

> The source :rubygems is deprecated because HTTP requests are insecure.
> Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.

This pull request does the above.
