### PR TITLE
Consider using .gitattributes to regulate newline endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
On Unix, newlines are denoted with LF (Line Feed or \n). On Windows, it is denoted with CRLF (carriage return + line feed or \r\n). A lot of windows and *nix editors change the line ending for a file to their respective line endings when saving. The problem with this is that Git sees these new line changes as additions and deletions, resulting in the entire files history being erased when the file is commited.

https://help.github.com/articles/dealing-with-line-endings

We should probably create a .gitattributes file to regulate everything to LF.
