### PR TITLE
Fix Travis CI test build by creating .env for Dotenv gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
   - redis-server
 rvm:
   - 2.1.1
+before_script: touch .env
 script: bundle exec rspec spec
 notifications:
   email:


### PR DESCRIPTION
The issue is a missing .env file, but I'm not sure if this is how we want to fix this.
