### PR TITLE
Adds license to repository

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@
 
 **Thanks:** Nick Silverman, Farmington High School Audio-Visual Department
 
-**Licence:** [The ☺ Licence](http://licence.visualidiot.com/)
+**Licence:** [The ☺ Licence](https://github.com/fhsav/clock/blob/master/license.md) _(Created by [VisualIdiot](http://visualidiot.com))_
 
 ## What is it?
 

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -65,6 +65,8 @@
               %a{:href => "http://github.com/fhsav/clock/issues"} Issues
             %li
               %a{:href => "/humans.txt"} Humans.txt
+            %li
+              %a{:href => "/license.txt"} License.txt
           %p.version= "#{CLOCK_VERSION}"
 
     = include_javascripts :admin

--- a/license.md
+++ b/license.md
@@ -1,0 +1,17 @@
+# SUMMARY (IN PLAIN-ENGLISH)
+
+Congratulations, you’ve got something with the best license ever.
+
+Basically, you’re free to do what you want with it; as long as you do something good (help someone out, smile; just be nice), you can use this on anything you fancy.
+
+Of course, if it all breaks, it’s totally not the author’s fault.
+Enjoy!
+
+
+# THE FULL LICENSE AGREEMENT
+
+By attaching this document to the given files (the “work”), you, the licensee, are hereby granted free usage in both personal and commercial environments, without any obligation of attribution or payment (monetary or otherwise). The licensee is free to use, copy, modify, publish, distribute, sublicense, and/or merchandise the work, subject to the licensee inflecting a positive message unto someone. This includes (but is not limited to): smiling, being nice, saying “thank you”, assisting other persons, or any similar actions percolating the given concept.
+
+The above copyright notice serves as a permissions notice also, and may optionally be included in copies or portions of the work.
+
+The work is provided “as is”, without warranty or support, express or implied. The author(s) are not liable for any damages, misuse, or other claim, whether from or as a consequence of usage of the given work.

--- a/public/license.txt
+++ b/public/license.txt
@@ -1,0 +1,25 @@
+/* SUMMARY (IN PLAIN-ENGLISH) */
+  Congratulations, you’ve got something with the best license ever.
+
+  Basically, you’re free to do what you want with it; as long as you do something
+  good (help someone out, smile; just be nice), you can use this on anything you fancy.
+
+  Of course, if it all breaks, it’s totally not the author’s fault.
+  Enjoy!
+
+/* THE FULL LICENSE AGREEMENT */
+  By attaching this document to the given files (the “work”), you, the licensee,
+  are hereby granted free usage in both personal and commercial environments,
+  without any obligation of attribution or payment (monetary or otherwise). The
+  licensee is free to use, copy, modify, publish, distribute, sublicense, and/or
+  merchandise the work, subject to the licensee inflecting a positive message unto
+  someone. This includes (but is not limited to): smiling, being nice, saying
+  “thank you”, assisting other persons, or any similar actions percolating the
+  given concept.
+
+  The above copyright notice serves as a permissions notice also, and may optionally
+  be included in copies or portions of the work.
+
+  The work is provided “as is”, without warranty or support, express or implied.
+  The author(s) are not liable for any damages, misuse, or other claim, whether
+  from or as a consequence of usage of the given work.


### PR DESCRIPTION
The ☺ License is no longer hosted on Visual Idiot's website. So I've added it to the repository and added a link in the footer of the site. 

Fixes #372 